### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/main/java/sample/Application.java
+++ b/sample/src/main/java/sample/Application.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/main/java/sample/User.java
+++ b/sample/src/main/java/sample/User.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/main/java/sample/UserController.java
+++ b/sample/src/main/java/sample/UserController.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/main/java/sample/UserRepository.java
+++ b/sample/src/main/java/sample/UserRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/main/java/sample/UserRepositoryUserDetailsRepository.java
+++ b/sample/src/main/java/sample/UserRepositoryUserDetailsRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/test/java/sample/SecurityTests.java
+++ b/sample/src/test/java/sample/SecurityTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *	  http://www.apache.org/licenses/LICENSE-2.0
+ *	  https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/sample/src/test/java/sample/UserRepositoryTests.java
+++ b/sample/src/test/java/sample/UserRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/access/ReactiveAccessDecisionManager.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/access/ReactiveAccessDecisionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/access/ReactiveAccessDecisionManagerAdapter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/access/ReactiveAccessDecisionManagerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/authentication/MapUserDetailsRepository.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/authentication/MapUserDetailsRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/authentication/ReactiveAuthenticationManager.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/authentication/ReactiveAuthenticationManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/authentication/ReactiveAuthenticationManagerAdapter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/authentication/ReactiveAuthenticationManagerAdapter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/AbstractServerWebExchangeMatcherRegistry.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/AbstractServerWebExchangeMatcherRegistry.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/AuthorizeRequestBuilder.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/AuthorizeRequestBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HeaderBuilder.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HeaderBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HttpBasicBuilder.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HttpBasicBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HttpSecurity.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/config/web/server/HttpSecurity.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/reactive/result/method/AuthenticationPrincipalArgumentResolver.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/reactive/result/method/AuthenticationPrincipalArgumentResolver.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthenticationEntryPoint.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthenticationEntryPoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthenticationWebFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthenticationWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthorizationWebFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/AuthorizationWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/CacheControlHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/CacheControlHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/CompositeHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/CompositeHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/ContentTypeOptionsHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/ContentTypeOptionsHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpBasicAuthenticationConverter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpBasicAuthenticationConverter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpHeaderWriterWebFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpHeaderWriterWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/HttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/SecurityContextRepositoryWebFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/SecurityContextRepositoryWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/StaticHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/StaticHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/StrictTransportSecurityHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/StrictTransportSecurityHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/WebFilterChainFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/WebFilterChainFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/XFrameOptionsHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/XFrameOptionsHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/DefaultServerWebExchangeExpressionHandler.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/DefaultServerWebExchangeExpressionHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/ExpressionReactiveAccessDecisionManager.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/ExpressionReactiveAccessDecisionManager.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/ServerWebExchangeMetadataSource.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/access/expression/ServerWebExchangeMetadataSource.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/authentication/www/HttpBasicAuthenticationEntryPoint.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/authentication/www/HttpBasicAuthenticationEntryPoint.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/SecurityContextRepository.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/SecurityContextRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/SecurityContextRepositoryServerWebExchange.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/SecurityContextRepositoryServerWebExchange.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/WebSessionSecurityContextRepository.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/context/WebSessionSecurityContextRepository.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/CacheControlHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/CacheControlHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/CompositeHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/CompositeHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/HttpHeaderWriterWebFilter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/HttpHeaderWriterWebFilter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/HttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/HttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/StaticHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/StaticHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XContentTypeOptionsHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XContentTypeOptionsHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XFrameOptionsHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XFrameOptionsHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XXssProtectionHttpHeadersWriter.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/header/XXssProtectionHttpHeadersWriter.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcher.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcher.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcher.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcher.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatcher.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatcher.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatchers.java
+++ b/spring-security-reactive/src/main/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatchers.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/authentication/MapUserDetailsRepositoryTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/authentication/MapUserDetailsRepositoryTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/authentication/UserDetailsAuthenticationManagerTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/authentication/UserDetailsAuthenticationManagerTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/test/web/reactive/server/WebTestClientBuilder.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/test/web/reactive/server/WebTestClientBuilder.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/test/web/reactive/server/WebTestHandler.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/test/web/reactive/server/WebTestHandler.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/CacheControlHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/CacheControlHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/CompositeHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/CompositeHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/HttpHeaderWriterWebFilterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/HttpHeaderWriterWebFilterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StaticHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StaticHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XContentTypeOptionsHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XContentTypeOptionsHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XFrameOptionsHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XFrameOptionsHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XXssProtectionHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/XXssProtectionHttpHeadersWriterTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcherTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/AndServerWebExchangeMatcherTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcherTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/OrServerWebExchangeMatcherTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcherTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/PathMatcherServerWebExchangeMatcherTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatchersTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/util/matcher/ServerWebExchangeMatchersTests.java
@@ -6,7 +6,7 @@
  *  * you may not use this file except in compliance with the License.
  *  * You may obtain a copy of the License at
  *  *
- *  *      http://www.apache.org/licenses/LICENSE-2.0
+ *  *      https://www.apache.org/licenses/LICENSE-2.0
  *  *
  *  * Unless required by applicable law or agreed to in writing, software
  *  * distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 with 70 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).