### PR TITLE
URL Cleanup

### DIFF
--- a/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriterTests.java
+++ b/spring-security-reactive/src/test/java/org/springframework/security/web/server/header/StrictTransportSecurityHttpHeadersWriterTests.java
@@ -86,7 +86,7 @@ public class StrictTransportSecurityHttpHeadersWriterTests {
 
 	@Test
 	public void writeHttpHeadersWhenHttpThenNoHeaders() {
-		exchange = MockServerHttpRequest.get("http://example.com/").toExchange();
+		exchange = MockServerHttpRequest.get("https://example.com/").toExchange();
 
 		hsts.writeHttpHeaders(exchange);
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://example.com/ with 1 occurrences migrated to:  
  https://example.com/ ([https](https://example.com/) result 200).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences